### PR TITLE
fix: add missing npm token into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Build CLI
         run: bun run build:cli
 
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
This pull request updates the release workflow to ensure npm authentication is configured before publishing. The most important change is the addition of a step that writes the npm authentication token to the `.npmrc` file using the `NPM_TOKEN` secret.

Release workflow improvement:

* Added a "Configure npm auth" step in `.github/workflows/release.yml` to write the npm authentication token to `~/.npmrc` using the `NPM_TOKEN` secret, ensuring proper authentication for npm publishing.