### PR TITLE
fix: add missing workflow_dispatch and environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment:
+      name: Production
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to improve deployment flexibility and environment management.

Workflow and environment improvements:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R7-R16): Added support for manual workflow triggers with `workflow_dispatch`, allowing releases to be triggered on demand.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R7-R16): Specified the deployment environment as `Production` for the release job, enhancing environment management and visibility.