### PR TITLE
fix: sanitize compilation names on release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,18 +72,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Everything below runs ONLY when a real release was published
-      # (Changesets sets outputs.published == 'true' in that case)
-
+      # ---------- Everything below runs ONLY when a real release was published ----------
       - name: Compute release tag + build metadata for CLI
         id: meta
         if: steps.changesets.outputs.published == 'true'
         run: |
           VERSION=$(jq -r .version packages/cli/package.json)
           TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          echo "TAG=@curl-runner/cli@${VERSION}" >> "$GITHUB_OUTPUT"
+          TAG="@curl-runner/cli@${VERSION}"
+          FILE_PREFIX="curl-runner-cli-${VERSION}"
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "TIME=$TIME" >> "$GITHUB_OUTPUT"
+          echo "FILE_PREFIX=$FILE_PREFIX" >> "$GITHUB_OUTPUT"
 
       - name: Build cross-platform Bun binaries
         if: steps.changesets.outputs.published == 'true'
@@ -114,22 +115,22 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           cd packages/cli
-          tar -czf curl-runner-linux-x64-${{ steps.meta.outputs.TAG }}.tar.gz    curl-runner-linux-x64
-          tar -czf curl-runner-linux-arm64-${{ steps.meta.outputs.TAG }}.tar.gz  curl-runner-linux-arm64
-          tar -czf curl-runner-darwin-x64-${{ steps.meta.outputs.TAG }}.tar.gz   curl-runner-darwin-x64
-          tar -czf curl-runner-darwin-arm64-${{ steps.meta.outputs.TAG }}.tar.gz curl-runner-darwin-arm64
-          zip        curl-runner-windows-x64-${{ steps.meta.outputs.TAG }}.zip   curl-runner-windows-x64.exe
+          tar -czf ${{ steps.meta.outputs.FILE_PREFIX }}-linux-x64.tar.gz    curl-runner-linux-x64
+          tar -czf ${{ steps.meta.outputs.FILE_PREFIX }}-linux-arm64.tar.gz  curl-runner-linux-arm64
+          tar -czf ${{ steps.meta.outputs.FILE_PREFIX }}-darwin-x64.tar.gz   curl-runner-darwin-x64
+          tar -czf ${{ steps.meta.outputs.FILE_PREFIX }}-darwin-arm64.tar.gz curl-runner-darwin-arm64
+          zip        ${{ steps.meta.outputs.FILE_PREFIX }}-windows-x64.zip   curl-runner-windows-x64.exe
 
       - name: Generate checksums
         if: steps.changesets.outputs.published == 'true'
         run: |
           cd packages/cli
           shasum -a 256 \
-            curl-runner-linux-x64-${{ steps.meta.outputs.TAG }}.tar.gz \
-            curl-runner-linux-arm64-${{ steps.meta.outputs.TAG }}.tar.gz \
-            curl-runner-darwin-x64-${{ steps.meta.outputs.TAG }}.tar.gz \
-            curl-runner-darwin-arm64-${{ steps.meta.outputs.TAG }}.tar.gz \
-            curl-runner-windows-x64-${{ steps.meta.outputs.TAG }}.zip \
+            ${{ steps.meta.outputs.FILE_PREFIX }}-linux-x64.tar.gz \
+            ${{ steps.meta.outputs.FILE_PREFIX }}-linux-arm64.tar.gz \
+            ${{ steps.meta.outputs.FILE_PREFIX }}-darwin-x64.tar.gz \
+            ${{ steps.meta.outputs.FILE_PREFIX }}-darwin-arm64.tar.gz \
+            ${{ steps.meta.outputs.FILE_PREFIX }}-windows-x64.zip \
             > SHA256SUMS.txt
 
       - name: Upload binaries + checksums to GitHub Release
@@ -138,11 +139,11 @@ jobs:
         with:
           tag_name: ${{ steps.meta.outputs.TAG }}
           files: |
-            packages/cli/curl-runner-linux-x64-${{ steps.meta.outputs.TAG }}.tar.gz
-            packages/cli/curl-runner-linux-arm64-${{ steps.meta.outputs.TAG }}.tar.gz
-            packages/cli/curl-runner-darwin-x64-${{ steps.meta.outputs.TAG }}.tar.gz
-            packages/cli/curl-runner-darwin-arm64-${{ steps.meta.outputs.TAG }}.tar.gz
-            packages/cli/curl-runner-windows-x64-${{ steps.meta.outputs.TAG }}.zip
+            packages/cli/${{ steps.meta.outputs.FILE_PREFIX }}-linux-x64.tar.gz
+            packages/cli/${{ steps.meta.outputs.FILE_PREFIX }}-linux-arm64.tar.gz
+            packages/cli/${{ steps.meta.outputs.FILE_PREFIX }}-darwin-x64.tar.gz
+            packages/cli/${{ steps.meta.outputs.FILE_PREFIX }}-darwin-arm64.tar.gz
+            packages/cli/${{ steps.meta.outputs.FILE_PREFIX }}-windows-x64.zip
             packages/cli/SHA256SUMS.txt
           fail_on_unmatched_files: true
         env:


### PR DESCRIPTION
This pull request updates the GitHub Actions release workflow to standardize and simplify how CLI binary artifact filenames are generated and referenced. The main improvement is the introduction of a `FILE_PREFIX` variable, which ensures consistent file naming across build, checksum, and upload steps.

**Release workflow improvements:**

- Added a `FILE_PREFIX` variable in the metadata step to standardize the naming of CLI binary artifacts, making filenames more predictable and easier to reference throughout the workflow.
- Updated the build, checksum generation, and GitHub Release upload steps to use the new `FILE_PREFIX` variable instead of constructing filenames with the release tag, reducing duplication and potential for errors. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L117-R133) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L141-R146)