### PR TITLE
fix: disable search

### DIFF
--- a/packages/docs/components/site-header.tsx
+++ b/packages/docs/components/site-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Menu, Search, Terminal } from 'lucide-react';
+import { Menu, Terminal } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
@@ -68,7 +68,7 @@ export function SiteHeader() {
           </nav>
 
           <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">
-            <div className="w-full flex-1 md:w-auto md:flex-none">
+            {/* <div className="w-full flex-1 md:w-auto md:flex-none">
               <Button
                 variant="outline"
                 className="relative h-8 w-full justify-start rounded-md bg-background text-sm font-normal text-muted-foreground shadow-none sm:pr-12 md:w-40 lg:w-64"
@@ -81,7 +81,7 @@ export function SiteHeader() {
                   <span className="text-xs">⌘</span>K
                 </kbd>
               </Button>
-            </div>
+            </div> */}
             <nav className="flex items-center gap-1">
               {/* <Button variant="ghost" size="icon" asChild className="h-8 w-8">
                 <a


### PR DESCRIPTION
This pull request makes a minor update to the `SiteHeader` component in the documentation site. The main change is the removal of the unused `Search` icon import and the commenting out of the search button UI, likely in preparation for future updates or cleanup.

UI cleanup:

* Removed the import of the unused `Search` icon from `lucide-react` in `site-header.tsx`.
* Commented out the search button markup within the header, disabling its display without deleting the code. [[1]](diffhunk://#diff-198b8ebeea60f3054f2719c231a3842d5da19fe63c477a16646a8690106ae58eL71-R71) [[2]](diffhunk://#diff-198b8ebeea60f3054f2719c231a3842d5da19fe63c477a16646a8690106ae58eL84-R84)