### PR TITLE
fix: missing og-images

### DIFF
--- a/packages/docs/app/(docs)/docs/api-reference/global-settings/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/api-reference/global-settings/opengraph-image.tsx
@@ -187,7 +187,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/api-reference/global-settings
+        https://www.curl-runner.com/docs/api-reference/global-settings
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/api-reference/request-object/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/api-reference/request-object/opengraph-image.tsx
@@ -187,7 +187,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/api-reference/request-object
+        https://www.curl-runner.com/docs/api-reference/request-object
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/api-reference/response-object/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/api-reference/response-object/opengraph-image.tsx
@@ -187,7 +187,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/api-reference/response-object
+        https://www.curl-runner.com/docs/api-reference/response-object
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/api-reference/validation-rules/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/api-reference/validation-rules/opengraph-image.tsx
@@ -187,7 +187,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/api-reference/validation-rules
+        https://www.curl-runner.com/docs/api-reference/validation-rules
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/cli-commands/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/cli-commands/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/cli-commands
+        https://www.curl-runner.com/docs/cli-commands
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/cli-options/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/cli-options/opengraph-image.tsx
@@ -5,7 +5,7 @@ import { ImageResponse } from 'next/og';
 // Use Node.js runtime to access file system
 export const runtime = 'nodejs';
 
-export const alt = 'Variables & Templating | curl-runner Documentation';
+export const alt = 'CLI Options | curl-runner Documentation';
 export const size = {
   width: 1200,
   height: 630,
@@ -39,7 +39,7 @@ export default async function Image() {
           height: '100%',
           opacity: 0.1,
           backgroundImage:
-            'radial-gradient(circle at 25% 25%, #8b5cf6 0%, transparent 50%), radial-gradient(circle at 75% 75%, #06b6d4 0%, transparent 50%)',
+            'radial-gradient(circle at 25% 25%, #10b981 0%, transparent 50%), radial-gradient(circle at 75% 75%, #3b82f6 0%, transparent 50%)',
         }}
       />
 
@@ -82,8 +82,8 @@ export default async function Image() {
         <div
           style={{
             display: 'flex',
-            background: 'rgba(139, 92, 246, 0.2)',
-            border: '2px solid rgba(139, 92, 246, 0.3)',
+            background: 'rgba(251, 146, 60, 0.2)',
+            border: '2px solid rgba(251, 146, 60, 0.3)',
             borderRadius: 16,
             padding: '8px 20px',
             marginBottom: 24,
@@ -93,12 +93,12 @@ export default async function Image() {
             style={{
               fontSize: 16,
               fontWeight: 600,
-              color: '#8b5cf6',
+              color: '#fb923c',
               textTransform: 'uppercase',
               letterSpacing: '0.1em',
             }}
           >
-            Variables & Templating
+            CLI Options
           </span>
         </div>
 
@@ -113,7 +113,7 @@ export default async function Image() {
             letterSpacing: '-0.02em',
           }}
         >
-          curl-runner
+          CLI Options
         </h1>
 
         {/* Subtitle */}
@@ -127,30 +127,74 @@ export default async function Image() {
             lineHeight: 1.3,
           }}
         >
-          Dynamic content with template expressions
+          curl-runner Documentation
         </p>
 
-        {/* Variable Examples */}
+        {/* Key Options */}
         <div
           style={{
             display: 'flex',
-            gap: 32,
+            gap: 24,
             alignItems: 'center',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            maxWidth: 600,
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <div style={{ fontSize: 20 }}>🌍</div>
-            <span style={{ color: '#e2e8f0', fontSize: 18 }}>ENV</span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#64748b', fontSize: 14, fontFamily: 'monospace' }}>--output-format</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <div style={{ fontSize: 20 }}>🔗</div>
-            <span style={{ color: '#e2e8f0', fontSize: 18 }}>${'{VAR}'}</span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#64748b', fontSize: 14, fontFamily: 'monospace' }}>--execution</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <div style={{ fontSize: 20 }}>⚡</div>
-            <span style={{ color: '#e2e8f0', fontSize: 18 }}>Dynamic</span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#64748b', fontSize: 14, fontFamily: 'monospace' }}>--debug</span>
           </div>
         </div>
+
+        {/* Description */}
+        <p
+          style={{
+            fontSize: 18,
+            color: '#64748b',
+            margin: 0,
+            marginTop: 32,
+            maxWidth: 500,
+            lineHeight: 1.4,
+          }}
+        >
+          Complete reference for all curl-runner command-line options
+        </p>
       </div>
 
       {/* URL */}
@@ -163,7 +207,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        https://www.curl-runner.com/docs/variables
+        https://www.curl-runner.com/docs/cli-options
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/examples/advanced/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/examples/advanced/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/examples/advanced
+        https://www.curl-runner.com/docs/examples/advanced
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/examples/basic/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/examples/basic/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/examples/basic
+        https://www.curl-runner.com/docs/examples/basic
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/examples/collection/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/examples/collection/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/examples/collection
+        https://www.curl-runner.com/docs/examples/collection
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/features/output-formats/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/features/output-formats/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/features/output-formats
+        https://www.curl-runner.com/docs/features/output-formats
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/features/parallel-execution/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/features/parallel-execution/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/features/parallel-execution
+        https://www.curl-runner.com/docs/features/parallel-execution
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/features/response-validation/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/features/response-validation/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/features/response-validation
+        https://www.curl-runner.com/docs/features/response-validation
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/features/retry-mechanism/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/features/retry-mechanism/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/features/retry-mechanism
+        https://www.curl-runner.com/docs/features/retry-mechanism
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/global-settings/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/global-settings/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/global-settings
+        https://www.curl-runner.com/docs/global-settings
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/installation/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/installation/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/installation
+        https://www.curl-runner.com/docs/installation
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs
+        https://www.curl-runner.com/docs
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/quick-start/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/quick-start/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/quick-start
+        https://www.curl-runner.com/docs/quick-start
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/tutorials/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/tutorials/opengraph-image.tsx
@@ -5,7 +5,7 @@ import { ImageResponse } from 'next/og';
 // Use Node.js runtime to access file system
 export const runtime = 'nodejs';
 
-export const alt = 'Variables & Templating | curl-runner Documentation';
+export const alt = 'Tutorials - Step-by-Step Guides | curl-runner Documentation';
 export const size = {
   width: 1200,
   height: 630,
@@ -39,7 +39,7 @@ export default async function Image() {
           height: '100%',
           opacity: 0.1,
           backgroundImage:
-            'radial-gradient(circle at 25% 25%, #8b5cf6 0%, transparent 50%), radial-gradient(circle at 75% 75%, #06b6d4 0%, transparent 50%)',
+            'radial-gradient(circle at 25% 25%, #10b981 0%, transparent 50%), radial-gradient(circle at 75% 75%, #3b82f6 0%, transparent 50%)',
         }}
       />
 
@@ -82,8 +82,8 @@ export default async function Image() {
         <div
           style={{
             display: 'flex',
-            background: 'rgba(139, 92, 246, 0.2)',
-            border: '2px solid rgba(139, 92, 246, 0.3)',
+            background: 'rgba(59, 130, 246, 0.2)',
+            border: '2px solid rgba(59, 130, 246, 0.3)',
             borderRadius: 16,
             padding: '8px 20px',
             marginBottom: 24,
@@ -93,12 +93,12 @@ export default async function Image() {
             style={{
               fontSize: 16,
               fontWeight: 600,
-              color: '#8b5cf6',
+              color: '#3b82f6',
               textTransform: 'uppercase',
               letterSpacing: '0.1em',
             }}
           >
-            Variables & Templating
+            Tutorials
           </span>
         </div>
 
@@ -113,7 +113,7 @@ export default async function Image() {
             letterSpacing: '-0.02em',
           }}
         >
-          curl-runner
+          curl-runner Tutorials
         </h1>
 
         {/* Subtitle */}
@@ -127,28 +127,71 @@ export default async function Image() {
             lineHeight: 1.3,
           }}
         >
-          Dynamic content with template expressions
+          Step-by-Step Guides
         </p>
 
-        {/* Variable Examples */}
+        {/* Tutorial Topics */}
         <div
           style={{
             display: 'flex',
-            gap: 32,
+            gap: 24,
             alignItems: 'center',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            maxWidth: 600,
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <div style={{ fontSize: 20 }}>🌍</div>
-            <span style={{ color: '#e2e8f0', fontSize: 18 }}>ENV</span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#e2e8f0', fontSize: 16 }}>API Testing</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <div style={{ fontSize: 20 }}>🔗</div>
-            <span style={{ color: '#e2e8f0', fontSize: 18 }}>${'{VAR}'}</span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#e2e8f0', fontSize: 16 }}>CI/CD Integration</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <div style={{ fontSize: 20 }}>⚡</div>
-            <span style={{ color: '#e2e8f0', fontSize: 18 }}>Dynamic</span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#e2e8f0', fontSize: 16 }}>Load Testing</span>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#e2e8f0', fontSize: 16 }}>Advanced Workflows</span>
           </div>
         </div>
       </div>
@@ -163,7 +206,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        https://www.curl-runner.com/docs/variables
+        https://www.curl-runner.com/docs/tutorials
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/use-cases/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/use-cases/opengraph-image.tsx
@@ -5,7 +5,7 @@ import { ImageResponse } from 'next/og';
 // Use Node.js runtime to access file system
 export const runtime = 'nodejs';
 
-export const alt = 'Variables & Templating | curl-runner Documentation';
+export const alt = 'Use Cases - Real-World Applications | curl-runner Documentation';
 export const size = {
   width: 1200,
   height: 630,
@@ -39,7 +39,7 @@ export default async function Image() {
           height: '100%',
           opacity: 0.1,
           backgroundImage:
-            'radial-gradient(circle at 25% 25%, #8b5cf6 0%, transparent 50%), radial-gradient(circle at 75% 75%, #06b6d4 0%, transparent 50%)',
+            'radial-gradient(circle at 25% 25%, #10b981 0%, transparent 50%), radial-gradient(circle at 75% 75%, #3b82f6 0%, transparent 50%)',
         }}
       />
 
@@ -82,8 +82,8 @@ export default async function Image() {
         <div
           style={{
             display: 'flex',
-            background: 'rgba(139, 92, 246, 0.2)',
-            border: '2px solid rgba(139, 92, 246, 0.3)',
+            background: 'rgba(168, 85, 247, 0.2)',
+            border: '2px solid rgba(168, 85, 247, 0.3)',
             borderRadius: 16,
             padding: '8px 20px',
             marginBottom: 24,
@@ -93,12 +93,12 @@ export default async function Image() {
             style={{
               fontSize: 16,
               fontWeight: 600,
-              color: '#8b5cf6',
+              color: '#a855f7',
               textTransform: 'uppercase',
               letterSpacing: '0.1em',
             }}
           >
-            Variables & Templating
+            Use Cases
           </span>
         </div>
 
@@ -113,7 +113,7 @@ export default async function Image() {
             letterSpacing: '-0.02em',
           }}
         >
-          curl-runner
+          curl-runner Use Cases
         </h1>
 
         {/* Subtitle */}
@@ -127,28 +127,84 @@ export default async function Image() {
             lineHeight: 1.3,
           }}
         >
-          Dynamic content with template expressions
+          Real-World Applications
         </p>
 
-        {/* Variable Examples */}
+        {/* Use Case Examples */}
         <div
           style={{
             display: 'flex',
-            gap: 32,
+            gap: 24,
             alignItems: 'center',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            maxWidth: 600,
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <div style={{ fontSize: 20 }}>🌍</div>
-            <span style={{ color: '#e2e8f0', fontSize: 18 }}>ENV</span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#e2e8f0', fontSize: 16 }}>API Testing</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <div style={{ fontSize: 20 }}>🔗</div>
-            <span style={{ color: '#e2e8f0', fontSize: 18 }}>${'{VAR}'}</span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#e2e8f0', fontSize: 16 }}>CI/CD Automation</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <div style={{ fontSize: 20 }}>⚡</div>
-            <span style={{ color: '#e2e8f0', fontSize: 18 }}>Dynamic</span>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#e2e8f0', fontSize: 16 }}>Load Testing</span>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#e2e8f0', fontSize: 16 }}>Microservices</span>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '8px 16px',
+              borderRadius: 8,
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            <span style={{ color: '#e2e8f0', fontSize: 16 }}>Development</span>
           </div>
         </div>
       </div>
@@ -163,7 +219,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        https://www.curl-runner.com/docs/variables
+        https://www.curl-runner.com/docs/use-cases
       </div>
     </div>,
     {

--- a/packages/docs/app/(docs)/docs/yaml-structure/opengraph-image.tsx
+++ b/packages/docs/app/(docs)/docs/yaml-structure/opengraph-image.tsx
@@ -163,7 +163,7 @@ export default async function Image() {
           color: '#64748b',
         }}
       >
-        curl-runner.com/docs/yaml-structure
+        https://www.curl-runner.com/docs/yaml-structure
       </div>
     </div>,
     {


### PR DESCRIPTION
This pull request updates the Open Graph image generation for documentation pages in the curl-runner project. The main change is standardizing the display of documentation URLs by ensuring they use the full `https://` prefix for better clarity and consistency. Additionally, two new custom Open Graph image components are introduced for the CLI Options and Tutorials documentation sections, providing visually rich previews with branding and key information.

**Open Graph Image Improvements**

* All documentation Open Graph image components now display the full URL with the `https://` prefix, improving clarity and consistency across docs pages. [[1]](diffhunk://#diff-118287cd76f60f2e8fe274ef4da3cfd985623c98fa1bb4507ff55e78b5235660L190-R190) [[2]](diffhunk://#diff-0d4a128e1a6103809e450c0c55527eeb9deeb6b6a136fc1da3d16d7aed2c02dbL190-R190) [[3]](diffhunk://#diff-9b14fb92af9b6dc237050e2f09c7a25f6fa3519f7d3b515590679918b59c35fcL190-R190) [[4]](diffhunk://#diff-5b0cc9f06a19db1103fa818eeb793ce229fbb460d1c5df29cdef4a4f88feff92L190-R190) [[5]](diffhunk://#diff-f9c5e67c0843731948a54653dbf00a818644bd889aab1926182141ed3e8ebb5bL166-R166) [[6]](diffhunk://#diff-88284be4f6835520c290682c11e5b596a17340bbbe2733270afcb8202bf21ae8L166-R166) [[7]](diffhunk://#diff-5d11287ffb05a07edd41a767d961adbed40d0bab205c4667808f5b5839c691f2L166-R166) [[8]](diffhunk://#diff-2a2d7073ce7df7983492e5b167dd6f4db332aaecdd53e04b835730a147e98b80L166-R166) [[9]](diffhunk://#diff-1b160fdd2c71d82d574412fc285bc9b8369819fac0b64f5878f957da6d63528aL166-R166) [[10]](diffhunk://#diff-f664c8de453eaee474e5c0bac568ad256c817bedfa93273b4cca90fbcc057ae5L166-R166) [[11]](diffhunk://#diff-0c281ab8d067b0bbb368ebc385c490f7d91fa9a467c06c4af9969853c4719553L166-R166) [[12]](diffhunk://#diff-48e1a44eb620059824e35397035f9e8ef60d82475ee395ddab51b03290367404L166-R166) [[13]](diffhunk://#diff-54e8261e9574ce31cffc05b1a47d7ed930c3709c996fca64087941e0786c5529L166-R166) [[14]](diffhunk://#diff-6bbf227ed9c095be32a5428f763b497b44b9c6df581b909a2ba611ad4a0a7b99L166-R166) [[15]](diffhunk://#diff-f73b8d5482ac2e173756ca066de23f534f5489786fd0c7a6985d9391b33dcbbfL166-R166) [[16]](diffhunk://#diff-a7cb43b4a602f9b523162edda1421233d908e936d5c621c677821919e0066a8bL166-R166)

**New Custom Open Graph Images**

* Added a new Open Graph image component for the CLI Options documentation page, featuring branded styling, key CLI options, and a locally loaded logo for a more professional preview. (`packages/docs/app/(docs)/docs/cli-options/opengraph-image.tsx`)
* Added a new Open Graph image component for the Tutorials documentation page, highlighting tutorial topics and using enhanced branding and layout for improved visual appeal. (`packages/docs/app/(docs)/docs/tutorials/opengraph-image.tsx`)