### PR TITLE
fix: npm publishing and url install script

### DIFF
--- a/.changeset/tiny-schools-say.md
+++ b/.changeset/tiny-schools-say.md
@@ -1,0 +1,5 @@
+---
+"@curl-runner/cli": patch
+---
+
+fix: include dist folder in npm package and fix install script version parsing

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "access": "public"
   },
   "files": [
-    "src",
+    "dist",
     "README.md"
   ],
   "devDependencies": {

--- a/packages/docs/public/install.sh
+++ b/packages/docs/public/install.sh
@@ -44,11 +44,13 @@ detect_arch() {
 
 # Get latest release version
 get_latest_version() {
-  local version
-  version=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-  if [ -z "$version" ]; then
+  local tag version
+  tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+  if [ -z "$tag" ]; then
     error "Failed to fetch latest version"
   fi
+  # Extract bare version from tag (e.g., "@curl-runner/cli@1.16.0" -> "1.16.0")
+  version=$(echo "$tag" | sed -E 's/.*@([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
   echo "$version"
 }
 


### PR DESCRIPTION
This pull request addresses packaging and installation issues for the `@curl-runner/cli` package. The changes ensure the correct files are included in the npm package and improve the reliability of the install script's version parsing.

Packaging improvements:
* Updated `package.json` to include the `dist` folder (instead of `src`) in the published npm package, ensuring the distributed files are correct.

Installation script fixes:
* Improved the version extraction logic in `install.sh` to correctly parse the version number from the GitHub release tag, fixing issues with installation from the latest release.

Documentation:
* Added a changeset describing the packaging and install script fixes.