### PR TITLE
fix: install sh script using wrong binary names

### DIFF
--- a/.changeset/tiny-schools-say.md
+++ b/.changeset/tiny-schools-say.md
@@ -2,4 +2,4 @@
 "@curl-runner/cli": patch
 ---
 
-fix: include dist folder in npm package and fix install script version parsing
+fix: include dist folder in npm package and fix install script download URL


### PR DESCRIPTION
This pull request updates the install script for the `@curl-runner/cli` package to fix issues with downloading the correct release assets from GitHub. The main improvements are to ensure the install script uses the proper tag in download URLs and to clarify the handling of binary file names during installation.

Install script improvements:

* Changed the version-fetching function in `install.sh` to return both the tag and the version, ensuring the correct GitHub release assets are referenced in download URLs.
* Updated the download logic in `install.sh` to use the release tag (not just the version) in the asset URLs, fixing a bug where downloads could fail due to incorrect paths. [[1]](diffhunk://#diff-1730289df9813fef1d7b9ec9132b6ccd4abd9b976da51bf29e4c870c11dd7168L46-R65) [[2]](diffhunk://#diff-1730289df9813fef1d7b9ec9132b6ccd4abd9b976da51bf29e4c870c11dd7168L182-R197)
* Improved binary installation by explicitly renaming the downloaded binary to the expected name in the install directory, avoiding confusion with platform-specific binary names.

Documentation update:

* Updated the changeset summary to clarify that the fix addresses the install script's download URL, not just version parsing.