### PR TITLE
fix: install sh script using wrong binary names

### DIFF
--- a/.changeset/funny-forks-hunt.md
+++ b/.changeset/funny-forks-hunt.md
@@ -1,0 +1,5 @@
+---
+"@curl-runner/cli": patch
+---
+
+fix: install script download URL and binary name extraction

--- a/packages/docs/public/install.sh
+++ b/packages/docs/public/install.sh
@@ -42,8 +42,8 @@ detect_arch() {
   esac
 }
 
-# Get latest release version
-get_latest_version() {
+# Get latest release (returns "tag version")
+get_latest_release() {
   local tag version
   tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
   if [ -z "$tag" ]; then
@@ -51,16 +51,17 @@ get_latest_version() {
   fi
   # Extract bare version from tag (e.g., "@curl-runner/cli@1.16.0" -> "1.16.0")
   version=$(echo "$tag" | sed -E 's/.*@([0-9]+\.[0-9]+\.[0-9]+)$/\1/')
-  echo "$version"
+  echo "$tag $version"
 }
 
 # Download and verify checksum
 download_and_verify() {
-  local version="$1"
-  local platform="$2"
+  local tag="$1"
+  local version="$2"
+  local platform="$3"
   local tarball="curl-runner-cli-${version}-${platform}.tar.gz"
-  local download_url="https://github.com/${REPO}/releases/download/${version}/${tarball}"
-  local checksum_url="https://github.com/${REPO}/releases/download/${version}/SHA256SUMS.txt"
+  local download_url="https://github.com/${REPO}/releases/download/${tag}/${tarball}"
+  local checksum_url="https://github.com/${REPO}/releases/download/${tag}/SHA256SUMS.txt"
   local tmp_dir
   tmp_dir=$(mktemp -d)
 
@@ -100,9 +101,9 @@ download_and_verify() {
   info "Extracting binary..."
   tar -xzf "$tarball"
 
-  # Move to install directory
+  # Move to install directory (binary is named curl-runner-{platform})
   mkdir -p "$INSTALL_DIR"
-  mv "$BINARY_NAME" "$INSTALL_DIR/"
+  mv "curl-runner-${platform}" "$INSTALL_DIR/${BINARY_NAME}"
   chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
   # Cleanup
@@ -179,7 +180,7 @@ main() {
   echo -e "${BLUE}curl-runner installer${NC}"
   echo ""
 
-  local os arch platform version
+  local os arch platform tag version release_info
 
   os=$(detect_os)
   arch=$(detect_arch)
@@ -187,10 +188,12 @@ main() {
 
   info "Detected platform: ${platform}"
 
-  version=$(get_latest_version)
+  release_info=$(get_latest_release)
+  tag=$(echo "$release_info" | cut -d' ' -f1)
+  version=$(echo "$release_info" | cut -d' ' -f2)
   info "Latest version: ${version}"
 
-  download_and_verify "$version" "$platform"
+  download_and_verify "$tag" "$version" "$platform"
   add_to_path
 
   echo ""


### PR DESCRIPTION
This pull request fixes issues with the install script for `@curl-runner/cli`, specifically around how the script determines the download URL and binary name. The main improvements are to the logic for extracting the latest release version and handling the binary file during installation.

**Install Script Fixes:**

* Changed `get_latest_version` to `get_latest_release`, which now returns both the full tag and bare version, improving accuracy when constructing download URLs.
* Updated `download_and_verify` to accept both the tag and version, ensuring the correct files are downloaded from GitHub releases. [[1]](diffhunk://#diff-1730289df9813fef1d7b9ec9132b6ccd4abd9b976da51bf29e4c870c11dd7168L45-R64) [[2]](diffhunk://#diff-1730289df9813fef1d7b9ec9132b6ccd4abd9b976da51bf29e4c870c11dd7168L182-R196)
* Fixed the binary move step to handle the actual extracted binary name (`curl-runner-${platform}`), renaming it to the expected `BINARY_NAME` in the install directory.

**Changelog:**

* Added a patch changelog entry for `@curl-runner/cli` describing these fixes.