### PR TITLE
fix: spawn curl directly instead of shell execution

### DIFF
--- a/.changeset/remove-shell-execution.md
+++ b/.changeset/remove-shell-execution.md
@@ -1,0 +1,7 @@
+---
+"@curl-runner/cli": patch
+---
+
+fix: spawn curl directly instead of shell execution
+
+Removes shell interpretation of ${...} variables in curl commands. Previously, unresolved variables would cause errors on macOS bash 3.2 and Debian dash. Now spawns curl directly with args array, uses --form-string for text form fields to prevent @/< interpretation.

--- a/packages/cli/src/executor/request-executor.ts
+++ b/packages/cli/src/executor/request-executor.ts
@@ -102,8 +102,8 @@ export class RequestExecutor {
       return failedResult;
     }
 
-    const command = CurlBuilder.buildCommand(config);
-    requestLogger.logCommand(command);
+    const args = CurlBuilder.buildCommand(config);
+    requestLogger.logCommand(CurlBuilder.formatCommandForDisplay(args));
 
     let attempt = 0;
     let lastError: string | undefined;
@@ -119,7 +119,7 @@ export class RequestExecutor {
         }
       }
 
-      const result = await CurlBuilder.executeCurl(command);
+      const result = await CurlBuilder.executeCurl(args);
 
       if (result.success) {
         let body = result.body;

--- a/packages/cli/src/utils/curl-builder.test.ts
+++ b/packages/cli/src/utils/curl-builder.test.ts
@@ -4,30 +4,33 @@ import { CurlBuilder } from './curl-builder';
 describe('CurlBuilder', () => {
   describe('buildCommand', () => {
     test('should build basic GET request', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/api',
         method: 'GET',
       });
 
-      expect(command).toContain('curl');
-      expect(command).toContain('-X GET');
-      expect(command).toContain('"https://example.com/api"');
+      expect(args).toContain('-X');
+      expect(args).toContain('GET');
+      expect(args).toContain('https://example.com/api');
     });
 
     test('should build POST request with JSON body', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/api',
         method: 'POST',
         body: { name: 'test' },
       });
 
-      expect(command).toContain('-X POST');
-      expect(command).toContain('-d \'{"name":"test"}\'');
-      expect(command).toContain('Content-Type: application/json');
+      expect(args).toContain('-X');
+      expect(args).toContain('POST');
+      expect(args).toContain('-d');
+      expect(args).toContain('{"name":"test"}');
+      expect(args).toContain('-H');
+      expect(args).toContain('Content-Type: application/json');
     });
 
     test('should build POST request with form data', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/upload',
         method: 'POST',
         formData: {
@@ -36,14 +39,16 @@ describe('CurlBuilder', () => {
         },
       });
 
-      expect(command).toContain('-X POST');
-      expect(command).toContain("-F 'username=john'");
-      expect(command).toContain("-F 'age=30'");
-      expect(command).not.toContain('-d');
+      expect(args).toContain('-X');
+      expect(args).toContain('POST');
+      expect(args).toContain('--form-string');
+      expect(args).toContain('username=john');
+      expect(args).toContain('age=30');
+      expect(args).not.toContain('-d');
     });
 
     test('should build POST request with file attachment', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/upload',
         method: 'POST',
         formData: {
@@ -53,11 +58,12 @@ describe('CurlBuilder', () => {
         },
       });
 
-      expect(command).toContain("-F 'document=@./test.pdf'");
+      expect(args).toContain('-F');
+      expect(args).toContain('document=@./test.pdf');
     });
 
     test('should build POST request with file attachment and custom filename', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/upload',
         method: 'POST',
         formData: {
@@ -68,11 +74,12 @@ describe('CurlBuilder', () => {
         },
       });
 
-      expect(command).toContain("-F 'document=@./test.pdf;filename=report.pdf'");
+      expect(args).toContain('-F');
+      expect(args).toContain('document=@./test.pdf;filename=report.pdf');
     });
 
     test('should build POST request with file attachment and content type', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/upload',
         method: 'POST',
         formData: {
@@ -83,11 +90,12 @@ describe('CurlBuilder', () => {
         },
       });
 
-      expect(command).toContain("-F 'data=@./data.json;type=application/json'");
+      expect(args).toContain('-F');
+      expect(args).toContain('data=@./data.json;type=application/json');
     });
 
     test('should build POST request with file attachment including all options', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/upload',
         method: 'POST',
         formData: {
@@ -99,13 +107,14 @@ describe('CurlBuilder', () => {
         },
       });
 
-      expect(command).toContain(
-        "-F 'document=@./report.pdf;filename=quarterly-report.pdf;type=application/pdf'",
+      expect(args).toContain('-F');
+      expect(args).toContain(
+        'document=@./report.pdf;filename=quarterly-report.pdf;type=application/pdf',
       );
     });
 
     test('should build POST request with mixed form data and files', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/upload',
         method: 'POST',
         formData: {
@@ -117,13 +126,15 @@ describe('CurlBuilder', () => {
         },
       });
 
-      expect(command).toContain("-F 'title=My Document'");
-      expect(command).toContain("-F 'description=Test upload'");
-      expect(command).toContain("-F 'file=@./document.pdf'");
+      expect(args).toContain('--form-string');
+      expect(args).toContain('title=My Document');
+      expect(args).toContain('description=Test upload');
+      expect(args).toContain('-F');
+      expect(args).toContain('file=@./document.pdf');
     });
 
-    test('should escape single quotes in form field values', () => {
-      const command = CurlBuilder.buildCommand({
+    test('should pass through single quotes in form field values', () => {
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/upload',
         method: 'POST',
         formData: {
@@ -131,11 +142,12 @@ describe('CurlBuilder', () => {
         },
       });
 
-      expect(command).toContain("-F 'message=It'\\''s a test'");
+      expect(args).toContain('--form-string');
+      expect(args).toContain("message=It's a test");
     });
 
     test('should prefer formData over body when both are present', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/api',
         method: 'POST',
         formData: {
@@ -144,12 +156,13 @@ describe('CurlBuilder', () => {
         body: { name: 'test' },
       });
 
-      expect(command).toContain("-F 'field=value'");
-      expect(command).not.toContain('-d');
+      expect(args).toContain('--form-string');
+      expect(args).toContain('field=value');
+      expect(args).not.toContain('-d');
     });
 
     test('should handle boolean form field values', () => {
-      const command = CurlBuilder.buildCommand({
+      const args = CurlBuilder.buildCommand({
         url: 'https://example.com/api',
         method: 'POST',
         formData: {
@@ -158,8 +171,47 @@ describe('CurlBuilder', () => {
         },
       });
 
-      expect(command).toContain("-F 'active=true'");
-      expect(command).toContain("-F 'disabled=false'");
+      expect(args).toContain('--form-string');
+      expect(args).toContain('active=true');
+      expect(args).toContain('disabled=false');
+    });
+
+    test('should pass through unresolved ${VAR} without shell interpretation', () => {
+      const args = CurlBuilder.buildCommand({
+        url: 'https://example.com/api/${VAR}',
+        method: 'GET',
+      });
+
+      // The ${VAR} should be in the URL literally, not interpreted
+      expect(args).toContain('https://example.com/api/${VAR}');
+    });
+
+    test('should handle JSON body with curly braces', () => {
+      const args = CurlBuilder.buildCommand({
+        url: 'https://example.com/api',
+        method: 'POST',
+        body: { nested: { key: 'value' } },
+      });
+
+      expect(args).toContain('-d');
+      expect(args).toContain('{"nested":{"key":"value"}}');
+    });
+  });
+
+  describe('formatCommandForDisplay', () => {
+    test('should format simple args', () => {
+      const display = CurlBuilder.formatCommandForDisplay(['-X', 'GET', 'https://example.com']);
+      expect(display).toBe('curl -X GET https://example.com');
+    });
+
+    test('should quote args with spaces', () => {
+      const display = CurlBuilder.formatCommandForDisplay(['-H', 'Content-Type: application/json']);
+      expect(display).toBe("curl -H 'Content-Type: application/json'");
+    });
+
+    test('should escape single quotes in args', () => {
+      const display = CurlBuilder.formatCommandForDisplay(['--form-string', "message=It's a test"]);
+      expect(display).toBe("curl --form-string 'message=It'\\''s a test'");
     });
   });
 });


### PR DESCRIPTION
This pull request updates the `@curl-runner/cli` package to improve how `curl` commands are constructed and executed. The main change is to avoid shell execution and instead spawn `curl` directly with an array of arguments, which prevents issues with shell variable interpretation and improves compatibility across platforms. The changes also update how form data and command formatting are handled, and revise the test suite accordingly.

**Execution and Security Improvements:**

* The CLI now spawns `curl` directly using an argument array instead of running through a shell, preventing shell interpretation of variables like `${VAR}` and fixing compatibility issues on macOS and Debian. [[1]](diffhunk://#diff-2dfce719cb4d267e3f29ed1aeb9fa393a80f3783ab0dafefe6a1afab7b4a8d8aR1-R7) [[2]](diffhunk://#diff-f79baf32208a8252ee8e9c644f85fcecb21581639a61cfd40447282507ca7088L148-R155)

**Command Construction and Formatting:**

* `CurlBuilder.buildCommand` now returns an array of arguments instead of a single command string, and uses `--form-string` for text form fields to avoid `@`/`<` interpretation, while still using `-F` for file attachments. [[1]](diffhunk://#diff-f79baf32208a8252ee8e9c644f85fcecb21581639a61cfd40447282507ca7088L21-R46) [[2]](diffhunk://#diff-f79baf32208a8252ee8e9c644f85fcecb21581639a61cfd40447282507ca7088L63-R138)
* Added a new `formatCommandForDisplay` method to safely format the argument array as a shell command string for logging and debugging. [[1]](diffhunk://#diff-f79baf32208a8252ee8e9c644f85fcecb21581639a61cfd40447282507ca7088L63-R138) [[2]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L161-R214)

**Code and Test Refactoring:**

* Updated all usages of `buildCommand` and `executeCurl` in the codebase to use argument arrays instead of command strings, and updated logging to use the new display formatting. [[1]](diffhunk://#diff-24f29952919222919d39cdd59173b9cfb2df71fccf04c1a40f03c3d3cb4bf5edL105-R106) [[2]](diffhunk://#diff-24f29952919222919d39cdd59173b9cfb2df71fccf04c1a40f03c3d3cb4bf5edL122-R122)
* Refactored and expanded the test suite to check for correct argument array construction, including edge cases like unresolved variables, single quotes, and JSON bodies. [[1]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L7-R33) [[2]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L39-R51) [[3]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L56-R66) [[4]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L71-R82) [[5]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L86-R98) [[6]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L102-R117) [[7]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L120-R150) [[8]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L147-R165) [[9]](diffhunk://#diff-edea1ab1daa71374bd7b44bd457152a28aefa00667a1661e8b7294e7d8772381L161-R214)

**Documentation:**

* Added a changeset describing the patch, the rationale for removing shell execution, and the behavior changes for form fields and variable handling.