### PR TITLE
chore: add companies using curl-runner to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 
 A powerful CLI tool and documentation website for HTTP request management using YAML configuration files. Built with [Bun](https://bun.sh) for blazing-fast performance and featuring a modern documentation site powered by Next.js.
 
+## 🏢 Companies using `curl-runner`
+
+<div align="center">
+  <a href="https://tiptap.dev"><img src="https://avatars.githubusercontent.com/u/16939337?v=4" alt="Tiptap" height="40"></a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://pulsora.co"><img src="https://pulsora.co/favicon.png" alt="Pulsora" height="40"></a>
+</div>
+
 ## ✨ Features
 
 ### 🎯 Core CLI Features


### PR DESCRIPTION
This pull request adds a new section to the `README.md` to highlight companies using `curl-runner`. This helps showcase real-world adoption and builds credibility for the project.

Documentation update:

* Added a "Companies using `curl-runner`" section to the `README.md`, featuring company logos and links for Tiptap and Pulsora.