### PR TITLE
fix trusted publishers missing setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
This pull request adds a new setup step to the release workflow to ensure Node.js version 22 is installed and configured for publishing to npm. This helps standardize the Node.js environment during releases.

- Workflow environment setup:
  * Added a `Setup Node` step using `actions/setup-node@v4` to install Node.js version 22 and set the npm registry URL in `.github/workflows/release.yml`.