### PR TITLE
feat(validation): add $absent and $exists body assertions

### DIFF
--- a/packages/cli/examples/advanced-validation.yaml
+++ b/packages/cli/examples/advanced-validation.yaml
@@ -17,6 +17,8 @@ requests:
         id: "^[0-9]+$" # Regex: any number
         userId: "*" # Wildcard: accept any value
         title: "^[a-zA-Z\\s]+" # Regex: letters and spaces
+        body: $exists # Key must be present (any value, incl. null)
+        nonExistentField: $absent # Key must NOT be present in the response
 
   # Multiple acceptable values
   - name: Multiple Acceptable Values

--- a/packages/cli/src/core/validation/validators.test.ts
+++ b/packages/cli/src/core/validation/validators.test.ts
@@ -238,6 +238,42 @@ describe('validateBodyProperties', () => {
     const errorsNoMatch = validateBodyProperties(5, [1, 2, 3], '');
     expect(errorsNoMatch).toHaveLength(1);
   });
+
+  test('$absent passes when nested key is missing', () => {
+    const errors = validateBodyProperties(
+      { data: { foo: 1 } },
+      { data: { cssStyles: '$absent' } },
+      '',
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test('$absent fails when nested key exists (even as null)', () => {
+    const errors = validateBodyProperties(
+      { data: { cssStyles: null } },
+      { data: { cssStyles: '$absent' } },
+      '',
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('data.cssStyles');
+    expect(errors[0]).toContain('absent');
+  });
+
+  test('$exists passes when nested key is present', () => {
+    const errors = validateBodyProperties(
+      { data: { token: 'abc' } },
+      { data: { token: '$exists' } },
+      '',
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test('$exists fails when nested key is missing', () => {
+    const errors = validateBodyProperties({ data: {} }, { data: { token: '$exists' } }, '');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('data.token');
+    expect(errors[0]).toContain('exist');
+  });
 });
 
 describe('validateValue', () => {
@@ -245,6 +281,24 @@ describe('validateValue', () => {
     expect(validateValue('anything', '*', 'path').isValid).toBe(true);
     expect(validateValue(123, '*', 'path').isValid).toBe(true);
     expect(validateValue(null, '*', 'path').isValid).toBe(true);
+  });
+
+  test('validates $absent', () => {
+    expect(validateValue(undefined as unknown as null, '$absent', 'path').isValid).toBe(true);
+    expect(validateValue('value', '$absent', 'path').isValid).toBe(false);
+    // Present key with null value still exists → fails
+    expect(validateValue(null, '$absent', 'path').isValid).toBe(false);
+    const result = validateValue('value', '$absent', 'myField');
+    expect(result.error).toContain('myField');
+    expect(result.error).toContain('absent');
+  });
+
+  test('validates $exists', () => {
+    expect(validateValue('value', '$exists', 'path').isValid).toBe(true);
+    expect(validateValue(0, '$exists', 'path').isValid).toBe(true);
+    // Present key with null value still exists → passes
+    expect(validateValue(null, '$exists', 'path').isValid).toBe(true);
+    expect(validateValue(undefined as unknown as null, '$exists', 'path').isValid).toBe(false);
   });
 
   test('validates exact match', () => {

--- a/packages/cli/src/core/validation/validators.ts
+++ b/packages/cli/src/core/validation/validators.ts
@@ -204,6 +204,28 @@ export function validateValue(
   expectedValue: JsonValue,
   path: string,
 ): ValueValidationResult {
+  // Property must be absent (key not present in body)
+  if (expectedValue === '$absent') {
+    if (actualValue !== undefined) {
+      return {
+        isValid: false,
+        error: `Expected ${path} to be absent, got ${JSON.stringify(actualValue)}`,
+      };
+    }
+    return { isValid: true };
+  }
+
+  // Property must exist with any value (stricter than '*', which passes when missing)
+  if (expectedValue === '$exists') {
+    if (actualValue === undefined) {
+      return {
+        isValid: false,
+        error: `Expected ${path} to exist, but it was absent`,
+      };
+    }
+    return { isValid: true };
+  }
+
   // Wildcard - accept any value
   if (expectedValue === '*') {
     return { isValid: true };

--- a/packages/docs/app/(docs)/docs/features/response-validation/page.tsx
+++ b/packages/docs/app/(docs)/docs/features/response-validation/page.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, Eye, Search, Shield, Target, Zap } from 'lucide-react';
+import { CheckCircle, Eye, Search, Shield, Target, XCircle, Zap } from 'lucide-react';
 import type { Metadata } from 'next';
 import { CodeBlockServer } from '@/components/code-block-server';
 import { H2, H3 } from '@/components/docs-heading';
@@ -81,7 +81,9 @@ request:
       username: "johndoe"
       email: "john@example.com"
       active: true
-      
+      token: $exists      # Key must be present (any value, incl. null)
+      deletedAt: $absent  # Key must NOT be present in the response
+
 # Partial matching
 request:
   name: Check API Response
@@ -319,10 +321,46 @@ export default function ResponseValidationPage() {
                     <div className="flex-1">
                       <h4 className="font-medium mb-2">Wildcard Match</h4>
                       <p className="text-sm text-muted-foreground mb-3">
-                        Use "*" to check for presence of a field with any value.
+                        Use "*" to match a field with any value (does not enforce presence).
                       </p>
                       <code className="text-xs bg-muted px-2 py-1 rounded">
-                        {'body: { token: "*" } # Field must exist'}
+                        {'body: { token: "*" } # Any value'}
+                      </code>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-lg border bg-card p-4">
+                  <div className="flex items-start gap-3">
+                    <div className="rounded-full bg-red-500/10 p-2">
+                      <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
+                    </div>
+                    <div className="flex-1">
+                      <h4 className="font-medium mb-2">Absence Match</h4>
+                      <p className="text-sm text-muted-foreground mb-3">
+                        Use "$absent" to assert a key is NOT present. Fails even if the value is
+                        null.
+                      </p>
+                      <code className="text-xs bg-muted px-2 py-1 rounded">
+                        {'body: { cssStyles: $absent } # Key must NOT exist'}
+                      </code>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-lg border bg-card p-4">
+                  <div className="flex items-start gap-3">
+                    <div className="rounded-full bg-green-500/10 p-2">
+                      <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
+                    </div>
+                    <div className="flex-1">
+                      <h4 className="font-medium mb-2">Existence Match</h4>
+                      <p className="text-sm text-muted-foreground mb-3">
+                        Use "$exists" to require a key to be present with any value (incl. null).
+                        Stricter than "*".
+                      </p>
+                      <code className="text-xs bg-muted px-2 py-1 rounded">
+                        {'body: { token: $exists } # Key must exist'}
                       </code>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

Closes #118. Adds two new body-assertion keywords so you can assert on a key's **presence**, not just its value:

- **`$absent`** — passes only when the key is missing from the response. Fails even if the key is present with a `null` value (matches the issue's requirement).
- **`$exists`** — passes when the key is present with any value (including `null`); fails when missing. Stricter than `*`, which still passes for a missing key (left unchanged for backward-compat).

```yaml
expect:
  status: 200
  body:
    data:
      cssStyles: $absent   # must NOT be in the response
      token: $exists       # must be present (any value)
```

## How it works

An absent key surfaces as `actualValue === undefined` in `validateValue`, while a present-but-`null` key surfaces as `null` — so `=== undefined` cleanly distinguishes the two. No traversal changes were needed: primitive string values already route through `validateValue`, so nested paths, array selectors, and top-level `body` all work automatically.

Scope: only the bare string forms `$absent`/`$exists` are handled (not inside `[...]` one-of arrays), keeping semantics simple — absence/existence is about the key, not a value match.

## Changes

- `packages/cli/src/core/validation/validators.ts` — handle `$absent`/`$exists` in `validateValue()`.
- `packages/cli/src/core/validation/validators.test.ts` — unit + nested end-to-end tests for both keywords. Full suite: **1181 pass / 0 fail**.
- `packages/docs/.../response-validation/page.tsx` — new "Absence Match" / "Existence Match" doc cards, reworded the Wildcard card (`*` = any value, not presence), and added usage to the body-validation example. Generated markdown is build-time regenerated.
- `packages/cli/examples/advanced-validation.yaml` — discoverable usage lines.

## Verification

- Unit/integration tests green.
- Manual run against a live endpoint confirmed both directions: `$absent` fails when the key exists (`expected absent, got 1`), `$exists` fails when the key is missing, and the passing case (present `$exists` + missing `$absent`) passes.
- Biome clean.

https://claude.ai/code/session_01WMdEK5o44kQuSWZhYmLnGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMdEK5o44kQuSWZhYmLnGA)_