### PR TITLE
chore: add changeset for $absent and $exists body assertions

### DIFF
--- a/.changeset/absent-exists-assertions.md
+++ b/.changeset/absent-exists-assertions.md
@@ -1,0 +1,5 @@
+---
+"@curl-runner/cli": minor
+---
+
+Add `$absent` and `$exists` body-assertion keywords for response validation. `$absent` asserts a key is not present in the response (fails even when the value is `null`); `$exists` asserts a key is present with any value (including `null`), stricter than `*`.


### PR DESCRIPTION
## Why

PR #121 (feat: `$absent`/`$exists` body assertions, closes #118) was merged **without a changeset**, so the Release workflow found nothing to publish and no release was cut. This adds the missing changeset to recover the release — no version was consumed, so nothing was lost.

## What

Adds a **minor** changeset for `@curl-runner/cli` (1.23.5 → **1.24.0**), since `$absent`/`$exists` are new features.

`bunx @changesets/cli status --verbose` confirms:

```
Packages to be bumped at minor
- @curl-runner/cli 1.24.0
```

## Release flow after merge

1. Merging this to `main` triggers the Release workflow → opens a `chore: version packages` PR (bumps to 1.24.0, updates changelog).
2. Merging that PR publishes `@curl-runner/cli@1.24.0` to npm and cuts the GitHub release with cross-platform binaries.

https://claude.ai/code/session_01WMdEK5o44kQuSWZhYmLnGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMdEK5o44kQuSWZhYmLnGA)_